### PR TITLE
Make sure to use the system sudo command

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ Sudo.Mac = function(command, end, count) {
   if (count >= 2) return end(new Error('Permission denied after several password prompts.'));
   if (/^sudo/i.test(command)) return end(new Error('Command should not contain "sudo".'));
   // Run sudo in non-interactive mode (-n).
-  Node.child.exec('sudo -n ' + command,
+  Node.child.exec('/usr/bin/sudo -n ' + command,
     function(error, stdout, stderr) {
       if (/sudo: a password is required/i.test(stderr)) {
         Sudo.Mac.prompt(


### PR DESCRIPTION
Some modules, like `windosu` expose a binary called `sudo`. By just
calling `sudo`, `sudo-prompt` might accidentally call a `sudo` command
which is not the system one, causing tons of confusions.

Fixes: https://github.com/jorangreef/sudo-prompt/issues/6