### PR TITLE
Allow pkexec to run X11 applications

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ function linuxExecute(binary, command, options, end) {
     string += '--sudo-mode ';
     string += '--description="' + escapeDoubleQuotes(options.name) + '" ';
   } else if (/pkexec/i.test(binary)) {
+    string += 'env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ';
     string += '--disable-internal-agent ';
   }
   string += command;


### PR DESCRIPTION
From `man pkexec`:

> pkexec will not allow you to run X11 applications as another user since
> the $DISPLAY and $XAUTHORITY environment variables are not set.

One solution is to create a custom policy for an application setting the
`org.freedesktop.policykit.exec.allow_gui` option, which causes these
environment variables to be retained, however an easier workaround is to
manually preserve them by using `env`.

Fixes: https://github.com/jorangreef/sudo-prompt/issues/15
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>