### PR TITLE
Escaped spaces in applet path

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ function MacOpen(instance, end) {
   var binary = Node.path.join(instance.path, 'Contents', 'MacOS', 'applet');
   // We must set the cwd so that the AppleScript can find the shell scripts.
   var options = { cwd: Node.path.dirname(binary) };
-  Node.child.exec(binary.replace(/ /g, '\\ '), options, end);
+  Node.child.exec('./applet', options, end);
 }
 
 function MacPropertyList(instance, end) {

--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ function MacOpen(instance, end) {
   var binary = Node.path.join(instance.path, 'Contents', 'MacOS', 'applet');
   // We must set the cwd so that the AppleScript can find the shell scripts.
   var options = { cwd: Node.path.dirname(binary) };
-  Node.child.exec(binary, options, end);
+  Node.child.exec(binary.replace(/ /g, '\\ '), options, end);
 }
 
 function MacPropertyList(instance, end) {


### PR DESCRIPTION
Applet path in ‘binary’ variable caused path not found error when
options.name included spaces
--
After I updated to latest I found the new MacOpen method was breaking since my options.name used spaces. Escaping the spaces fixed it. It might not be exhaustive, and I've only dealt with OSX but this little update sorted it for me.

If you see anything that refers to or implies wrapping the path in quotes that's because I changed approach from wrapping in quotes to escaping the spaces.