### PR TITLE
Set `process.noAsar` when calling child_process.exec in Attempt()

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,11 @@ function Attempt(instance, end) {
   command.push('-n');
   command.push(instance.command);
   command = command.join(' ');
+  var originalProcessNoAsar = process.noAsar;
+  process.noAsar = true;
   Node.child.exec(command,
     function(error, stdout, stderr) {
+      process.noAsar = originalProcessNoAsar;
       if (/sudo: /i.test(stderr)) {
         var platform = Node.process.platform;
         if (platform === 'linux') {


### PR DESCRIPTION
I've encountered a very strange issue when executing a command
containing the path to an `asar` archive in Electron.

Turns out NodeJS implements `child_process.exec` by simply passing the
whole command to `child_process.execFile`. See:

- https://github.com/nodejs/node/blob/master/lib/child_process.js#L90
- https://github.com/nodejs/node/blob/master/lib/child_process.js#L99

Electron patches `child_process.execFile` to add support for `asar`
archives by injecting logic that extracts the required files from the
`asar` to a temporary location before delegating the work to the
original `child_process.execFile`.

In order to decide whether to inject the custom `asar` extracting logic,
Electron makes use of a helper function called `splitPath()`. See:

- https://github.com/electron/electron/blob/master/lib/common/asar.js#L37

If the first argument of the returned array equals `true`, means that
the path is considered to be an `asar` archive, and thus the extraction
logic takes place. The problem is that if the command passed to
`child_process.execFile` *contains* a path to an asar archive, padded
with other commands/arguments, `splitPath()` will consider it to be an
`asar` archive, and will try to extract it, throwing a rightfully
`Invalid package` error.

For example, let's say you pass the following command to
`sudoPrompt.exec`:

```sh
electron app.asar/index.js
```

The `Attempt()` function will then call `child_process.exec` with:

```sh
/usr/bin/sudo -n electron app.asar/index.js
```

Since the string `.asar` is present in the command, `splitPath()` will
consider `/usr/bin/sudo -n electron app.asar/index.js` to be a path to
an `asar` archive, and will fail with the above mentioned error.

A good enough workaround to this issue, at least until its correctly
fixed in Electron, its to manually disable `asar` support by setting
`process.noAsar` right before calling `child_process.exec`, and
reverting its value to its original one afterwards.

For more information about this issue, please take a look at the
following Electron issue: https://github.com/electron/electron/issues/5571

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>