### PR TITLE
Don't keep parsing command options in gksudo

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,9 @@ function Linux(instance, end) {
         command.push('--sudo-mode');
         var description = EscapeDoubleQuotes(instance.options.name);
         command.push('--description="' + description + '"');
+        command.push('--');
+      } else if (/kdesudo/i.test(binary)) {
+        command.push('--');
       } else if (/pkexec/i.test(binary)) {
         command.push('--disable-internal-agent');
       }


### PR DESCRIPTION
When `gksudo` is detected, this module executes the following command:

```
"/usr/bin/gksudo" --preserve-env --sudo-mode --description="MyApp" <COMMAND>
```

Consider the following command:

```
/home/jviotti/Projects/etcher/node_modules/electron-prebuilt/dist/electron /home/jviotti/Projects/etcher/lib/src/run-child-writer.js lib/start.js /home/jviotti/Downloads/CorePlus-current.iso --robot --drive /dev/sdb --unmount --check
```

Given that the command I'm running contains option arguments, it seems
like `gksudo` tries to interpret the options to my command as `gksudo`
options, failing with errors like this one:

```
/usr/bin/gksudo: unrecognized option '--robot'
```

To prevent this from happening, we can tell `gksudo` to stop parsing
options with the `--` identifier.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>