### PR TITLE
Don't keep parsing command options in sudo

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function Attempt(instance, end) {
   command.push('-n');
   // Preserve user environment:
   command.push('-E');
+  // Stop parsing command options:
+  command.push('--');
   command.push(instance.command);
   command = command.join(' ');
   Node.child.exec(command,


### PR DESCRIPTION
This commit is very similar to 3f6c485. It implements the fix to the
same problem for `sudo` when the module makes an attempt to determine if
the dialog needs to be shown or not.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>