### PR TITLE
Pass the `--comment` option to kdesudo to improve dialog

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,8 @@ function Linux(instance, end) {
       var command = [];
       command.push('"' + EscapeDoubleQuotes(binary) + '"');
       if (/kdesudo/i.test(binary)) {
+        var reason = 'needs administrative privileges. Please enter your password.';
+        command.push('--comment', '"' + instance.options.name + ' ' + reason + '"');
         command.push('--');
       } else if (/pkexec/i.test(binary)) {
         command.push('--disable-internal-agent');


### PR DESCRIPTION
Otherwise, `kdesudo` also displays the command as the dialog title,
making it very ugly and unfriendly.

Before: 

![screenshot_20160616_130914](https://cloud.githubusercontent.com/assets/2192773/16125911/d7249634-33c3-11e6-8d6b-9a189bfbf8ea.png)

After:

![screenshot_20160616_130943](https://cloud.githubusercontent.com/assets/2192773/16125916/db990024-33c3-11e6-861b-530e8d19dd58.png)

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>