### PR TITLE
Add TypeScript typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export function exec(cmd: string, options: { name?: string, icns?: string }, callback: (error: string, stdout: string, stderr: string) => void): void;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "9.0.0",
   "description": "Run a command using sudo, prompting the user with an OS dialog if necessary",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
This allows VSCode to remove our `sudo-prompt.d.ts` in our repo.

Refs: https://github.com/microsoft/vscode/issues/83421