### PR TITLE
Add env to options in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,4 @@
-export function exec(cmd: string, options: { name?: string, icns?: string, env?: { [key: string]: string } }, callback: (error: string, stdout: string, stderr: string) => void): void;
+export function exec(cmd: string,
+        options?: ((error?: Error, stdout?: string | Buffer, stderr?: string | Buffer) => void)
+                | { name?: string, icns?: string, env?: { [key: string]: string } },
+        callback?: (error: Error, stdout: string | Buffer, stderr: string | Buffer) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export function exec(cmd: string, options: { name?: string, icns?: string }, callback: (error: string, stdout: string, stderr: string) => void): void;
+export function exec(cmd: string, options: { name?: string, icns?: string, env?: { [key: string]: string } }, callback: (error: string, stdout: string, stderr: string) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 export function exec(cmd: string,
         options?: ((error?: Error, stdout?: string | Buffer, stderr?: string | Buffer) => void)
                 | { name?: string, icns?: string, env?: { [key: string]: string } },
-        callback?: (error: Error, stdout: string | Buffer, stderr: string | Buffer) => void): void;
+        callback?: (error?: Error, stdout?: string | Buffer, stderr?: string | Buffer) => void): void;


### PR DESCRIPTION
Fixes #117

This PR introduces 4 changes to the exec function typescript definition, making it compliant with the javascript code.
* Makes parameters *options* and *callback* optional
* If only 2 parameters are passed to exec,  the second parameter is the callback function 
*  Adds the optional *env* field to options
* Allows *callback* stdout and stderr fields to be Buffers